### PR TITLE
Add new rule: assignments to jQuery objects must use $var naming scheme

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,7 +17,7 @@
     "dollar-sign"
   ],
   "rules": {
-    "dollar-sign/dollar-sign": [2, "ignoreProperties"],
+    "dollar-sign/dollar-sign": ["error", "ignoreProperties"],
     "func-names": "off",
     "indent": ["error", 4],
     "max-len": ["error", 120],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,11 @@
   "parserOptions": {
       "ecmaVersion": 5
   },
+  "plugins": [
+    "dollar-sign"
+  ],
   "rules": {
+    "dollar-sign/dollar-sign": [2, "ignoreProperties"],
     "func-names": "off",
     "indent": ["error", 4],
     "max-len": ["error", 120],

--- a/README.md
+++ b/README.md
@@ -49,6 +49,22 @@ For the most part, edX follows the thoroughly documented [Airbnb JavaScript Styl
 
 In addition to the base Airbnb rules, edX adds or extends several of our own. They are described below.
 
+####[`dollar-sign`](https://github.com/erikdesjardins/eslint-plugin-dollar-sign)
+- **Setting**: `[2, "ignoreProperties"]`
+- **Explanation**: All variables that represent jQuery objects should be named starting with a `$`. Object properties may ignore this rule.
+- **Example**:
+
+    ```javascript
+    // Correct pattern
+    var $fooSpan = $('span#foo');
+
+    var ignoreProps = {};
+    ignoreProps.fooSpan = $('span#foo');
+
+    // Linter error
+    var fooSpan = $('span#foo');
+    ```
+
 ####[`func-names`](http://eslint.org/docs/rules/func-names)
 - **Setting**: `"off"`
 - **Explanation**: Ignore this rule, it doesn't play nicely with RequireJS code.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ For the most part, edX follows the thoroughly documented [Airbnb JavaScript Styl
 In addition to the base Airbnb rules, edX adds or extends several of our own. They are described below.
 
 ####[`dollar-sign`](https://github.com/erikdesjardins/eslint-plugin-dollar-sign)
-- **Setting**: `[2, "ignoreProperties"]`
+- **Setting**: `["error", "ignoreProperties"]`
 - **Explanation**: All variables that represent jQuery objects should be named starting with a `$`. Object properties may ignore this rule.
 - **Example**:
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "eslint": "^2.13.1",
     "eslint-config-airbnb-base": "^3.0.1",
+    "eslint-plugin-dollar-sign": "0.0.5",
     "eslint-plugin-import": "^1.9.2"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "peerDependencies": {
     "eslint": "^2.12.0",
+    "eslint-plugin-dollar-sign": "0.0.5",
     "eslint-plugin-import": "^1.9.2"
   }
 }


### PR DESCRIPTION
This can catch some safe template linter violations, and is good style to keep track of what's a jQuery object and what isn't.


@andy-armstrong proposed this rule, would love to hear feedback from @AlasdairSwan @dsjen @alisan617 as well.