### PR TITLE
Make tests more rigorous

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
 language: node_js
 node_js:
   - node
+env:
+  - NPMV=npm@2
+  - NPMV=npm@3
+before_install:
+  - npm install -g $NPMV
+  - npm --version

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "ESLint config for edX JavaScript code.",
   "main": "index.js",
   "scripts": {
-    "test": "pushd test && npm install && npm test && popd"
+    "test": "cd test && npm install && npm test && cd ../"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "ESLint config for edX JavaScript code.",
   "main": "index.js",
   "scripts": {
-    "test": "eslint ."
+    "test": "pushd test && npm install && npm test && popd"
   },
   "repository": {
     "type": "git",

--- a/test/package.json
+++ b/test/package.json
@@ -1,0 +1,11 @@
+{
+    "scripts": {
+        "test": "./node_modules/.bin/eslint test.js"
+    },
+    "devDependencies": {
+        "eslint-config-edx": "file:../../eslint-config-edx"
+    },
+    "eslintConfig": {
+        "extends": "eslint-config-edx"
+    }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,10 @@
+(function() {
+    'use strict';
+
+    var simpleESLintTest = 'This file should have no errors';
+
+    if (simpleESLintTest.charAt(0) === 'X') {
+        return false;
+    }
+    return true;
+}());


### PR DESCRIPTION
Now, instead of just linting itself, Travis will try to actually install the linter into a fake Node project and use it to lint a small JS file.

This is an improvement because now we know that `eslint-config-edx` has all of the right dependencies to actually work when it's installed somewhere.