### PR TITLE
Better tests, take 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+test/nodeenv

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: node_js
 node_js:
   - node
 env:
-  - NPMV=npm@2
-  - NPMV=npm@3
-before_install:
-  - npm install -g $NPMV
-  - npm --version
+  - NPMV=2
+  - NPMV=3
+script:
+  - ./test.sh

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "ESLint config for edX JavaScript code.",
   "main": "index.js",
   "scripts": {
-    "test": "cd test && npm install && npm test && cd ../"
+    "test": "./test.sh"
   },
   "repository": {
     "type": "git",

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -e
+
+pushd test
+
+# Install node environment isolation tool nodeenv
+if command -v nodeenv 2>/dev/null 1>/dev/null; then
+  echo "nodeenv already installed"
+else
+  # Travis won't let you write to /usr/local/bin, but ~/.local/lib/python is in Travis' PATH
+  pip install nodeenv || pip install --user nodeenv
+fi
+
+# Destroy (if necessary), create and activate nodeenv
+rm -rf node_modules
+rm -rf nodeenv
+nodeenv --node=system nodeenv
+. nodeenv/bin/activate
+
+# Get the right version of NPM active in the nodeenv
+# If no NPMV is set, we're testing locally - just use whatever's available already
+NPMV=${NPMV:-`npm --version`}
+npm install -g npm@$NPMV
+
+deactivate_node
+. nodeenv/bin/activate
+
+echo "Node version in nodeenv: `node --version`"
+echo "NPM version in nodeenv: `npm --version`"
+
+# Install eslint-config-edx
+npm install
+
+# Make sure eslint can run with our config
+npm test
+
+popd test

--- a/test/.eslintignore
+++ b/test/.eslintignore
@@ -1,0 +1,1 @@
+nodeenv

--- a/test/package.json
+++ b/test/package.json
@@ -1,9 +1,11 @@
 {
+    "name": "eslint-config-edx-test",
+    "version": "0.0.0",
     "scripts": {
-        "test": "./node_modules/.bin/eslint test.js"
+        "test": "eslint test.js"
     },
     "devDependencies": {
-        "eslint-config-edx": "file:../../eslint-config-edx"
+        "eslint-config-edx": "file:../"
     },
     "eslintConfig": {
         "extends": "eslint-config-edx"


### PR DESCRIPTION
Previous testing approach (#9) was faulty because npm will do a directory traversal to find packages missing from the closest `node_modules` - so errors with missing plugins in the `test` directory went unnoticed. This cleans that approach up using `nodeenv` -- package isolation similar to python's `virtualenv` -- so all that affects the `test` app is what it explicitly installs.