### PR TITLE
Remove quote-props rule.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,7 +27,6 @@
     "object-curly-spacing": ["error", "never"],
     "one-var": "off",
     "one-var-declaration-per-line": ["error", "initializations"],
-    "quote-props": ["error", "consistent-as-needed"],
     "space-before-function-paren": ["error", "never"],
     "strict": ["error", "function"]
   }

--- a/README.md
+++ b/README.md
@@ -192,41 +192,6 @@ In addition to the base Airbnb rules, edX adds or extends several of our own. Th
     var foo, bar, fizz = 'buzz', fozz = 'bizz';
     ```
 
-####[`quote-props`](http://eslint.org/docs/rules/quote-props)
-- **Setting**: `["error", "consistent-as-needed"]`
-- **Explanation**: If no properties of an object need to be wrapped in quotes (i.e., they are all camelCased strings), then they may remain unwrapped by quotes. If any object property requires quotes, then wrap all object properties in quotes regardless of their individual need for it.
-- **Example**:
-
-    ```javascript
-    // Correct patterns
-    var foo = {
-        bar: 'buzz',
-        biff: 'bop'
-    };
-
-    var foo2 = {
-        'bar': 'buzz',
-        'uh-oh-kebab-cased': 'bop'
-    };
-
-    // Linter errors
-    var foo = {
-        'bar': 'buzz',
-        'biff': 'bop'
-    };
-
-    var foo2 = {
-        bar: 'buzz',
-        'uh-oh-kebab-cased': 'bop'
-    };
-
-    // Syntax error
-    var foo2 = {
-        bar: 'buzz',
-        uh-oh-kebab-cased: 'bop'
-    };
-    ```
-
 ####[`space-before-function-paren`](http://eslint.org/docs/rules/space-before-function-paren)
 - **Setting**: `["error", "never"]`
 - **Explanation**: Do not add a space between a function and the opening parentheses containing its arguments, whether the function is anonymous or named.

--- a/test/test.js
+++ b/test/test.js
@@ -1,10 +1,19 @@
 (function() {
     'use strict';
 
-    var simpleESLintTest = 'This file should have no errors';
+    var propertyQuote = {
+            bar: 'buzz',
+            'mixed-quote-prop': 'mixed quotes are ok!'
+        },
+        simpleESLintTest = 'This file should have no errors';
+
+    if (propertyQuote.bar === 'X') {
+        return false;
+    }
 
     if (simpleESLintTest.charAt(0) === 'X') {
         return false;
     }
+
     return true;
 }());


### PR DESCRIPTION
The decision from https://github.com/edx/eslint-config-edx/issues/10 is to loosen the `quote-props` rule.  I didn't see a way to adjust the setting to address the looser style, and I think removing it entirely does the trick.

Please review: @bjacobel 

I'm looking for another thumb from any of the following: @AlasdairSwan @alisan617 @ajpal @andy-armstrong @thallada