### PR TITLE
Relax 'strict' rule to 'safe'

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,7 +11,10 @@
     "RequireJS": true
   },
   "parserOptions": {
-      "ecmaVersion": 5
+      "ecmaVersion": 5,
+      "ecmaFeatures": {
+        "globalReturn": false
+      }
   },
   "plugins": [
     "dollar-sign"
@@ -28,6 +31,6 @@
     "one-var": "off",
     "one-var-declaration-per-line": ["error", "initializations"],
     "space-before-function-paren": ["error", "never"],
-    "strict": ["error", "function"]
+    "strict": ["error", "safe"]
   }
 }

--- a/README.md
+++ b/README.md
@@ -218,6 +218,47 @@ In addition to the base Airbnb rules, edX adds or extends several of our own. Th
     ```
 
 ####[`strict`](http://eslint.org/docs/rules/strict)
-- **Setting**: `["error", "function"]`
-- **Explanation**: Every top-level function declaration must have a `'use strict';` in it. Do not use `'use strict';` anywhere else.
-- **Example**: See the [ESLint `strict` rule docs](http://eslint.org/docs/rules/strict) and the [MDN strict mode docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode).
+- **Setting**: `["error", "safe"]`
+- **Explanation**: If you're writing code that will run in the browser (i.e., AMD modules used by RequireJS), every top-level function declaration must have a `'use strict';` in it. Do not use `'use strict';` anywhere else. If you're writing code that will run in Node (i.e., a CommonJS module, Karma config or Gulp task), use a single `'use strict';` at global scope at the top of the module.
+- **Example**:
+	- For browser code:
+
+	    ```javascript
+	    (function(define) {
+	        'use strict';
+
+	        define(['foo'], function(foo) {
+	            foo();
+	        });
+	    }());
+		```
+
+	- For Node code:
+
+	    ```javascript
+	    /* eslint-env node */
+	    'use strict';
+	    var foo = require('foo');
+	    foo();
+	    ```
+
+		Instead of a `/* eslint-env node */` directive, you can also tell ESLint that a directory of `.js` files should be treated as Node-specific code with a directory-specific `.eslintrc.json`:
+
+	    ```
+	    project
+	    ├── .eslintrc.json
+	    ├── browser
+	    │   └── amd-module.js
+	    └── node
+	        ├── .eslintrc.json
+            ├── commonjs-module-1.js
+	        └── commonjs-module-2.js
+	    ```
+
+		`project/node/.eslintrc.json`:
+
+	    ```
+	    {
+	        "env": "node"
+	    }
+	    ```

--- a/test.sh
+++ b/test.sh
@@ -35,4 +35,6 @@ npm install
 # Make sure eslint can run with our config
 npm test
 
+rm -rf nodeenv
+
 popd test

--- a/test/amd-test.js
+++ b/test/amd-test.js
@@ -1,0 +1,7 @@
+(function(define) {
+    'use strict';
+
+    define(['./test.js'], function(test) {
+        test();
+    });
+}());

--- a/test/commonjs-test.js
+++ b/test/commonjs-test.js
@@ -1,0 +1,6 @@
+/* eslint-env node */
+
+'use strict';
+
+var test = require('./test.js');
+test();

--- a/test/package.json
+++ b/test/package.json
@@ -2,7 +2,7 @@
     "name": "eslint-config-edx-test",
     "version": "0.0.0",
     "scripts": {
-        "test": "eslint test.js"
+        "test": "eslint ."
     },
     "devDependencies": {
         "eslint-config-edx": "file:../"

--- a/test/test.js
+++ b/test/test.js
@@ -1,19 +1,31 @@
-(function() {
+(function(root, factory) {
     'use strict';
 
-    var propertyQuote = {
-            bar: 'buzz',
-            'mixed-quote-prop': 'mixed quotes are ok!'
-        },
-        simpleESLintTest = 'This file should have no errors';
-
-    if (propertyQuote.bar === 'X') {
-        return false;
+    if (typeof define === 'function' && define.amd) {
+        // Export as AMD, for RequireJS
+        define([], factory);
+    } else if (typeof module === 'object' && module.exports) {
+        // Export as CommonJS, for Node
+        module.exports = factory();
     }
+}(this, function() {
+    'use strict';
 
-    if (simpleESLintTest.charAt(0) === 'X') {
-        return false;
-    }
+    return function() {
+        var propertyQuote = {
+                bar: 'buzz',
+                'mixed-quote-prop': 'mixed quotes are ok!'
+            },
+            simpleESLintTest = 'This file should have no errors';
 
-    return true;
-}());
+        if (propertyQuote.bar === 'X') {
+            return false;
+        }
+
+        if (simpleESLintTest.charAt(0) === 'X') {
+            return false;
+        }
+
+        return true;
+    };
+}));


### PR DESCRIPTION
Currently, our setting of the [`strict`](http://eslint.org/docs/rules/strict) rule is `"function"` - meaning a `'use strict'` statement should appear as the first line of every function, and not appear in any other case.

This works fine for browser (AMD) code, which is the case I had in mind when I picked this setting. However, for code which runs in Node, wrapping everything in a `(function() { ... }());` just to be able to use `'use strict'` doesn't make much sense, as CommonJS modules each get their own scope, so wrapping each in an IIFE is pointless.

To get around this, we've been doing things like [setting a rule override just for the UXPL's `gulp` folder for the strict rule](https://github.com/edx/ux-pattern-library/blob/master/gulp/.eslintrc.json), so the Node code in the gulp tasks can `'use strict'` like Node code should. However, setting a per-folder rule override isn't practical in more complicated repos like edx-platform, where there's Karma and RequireJS config all over the place.

Instead, I think we should be using the `"safe"` option for strict, which determines if the file is a CommonJS module and sets `strict` to `global` if so, and `function` if not. (The determination is done with a per-file environment directive - `/* eslint-env node */` - that can be used to flip other globals and rules between node and non-Node code as well) **Edit**: it can also be done with a per-folder .eslintrc.json, like so:

```json
{
  "env": "node"
}
```


FYI: the Airbnb setting for this rule is to not allow you to use `'use strict'` anywhere, because they run all of their code through Babel (even their ES5) which adds `'use strict'` for you. So even though the eslint `strict` default is `safe`, we can't omit it from our rules entirely.


- [x] @andy-armstrong 
- [x] @dsjen 
- [x] @AlasdairSwan 
- [ ] @alisan617