### PR TITLE
Release 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.2.1 (2016-08-04)
+* Change `strict` rule from `"function"` to `"safe"`.
+
 ## 1.2.0 (2016-07-08)
 * Removed quote-props rule (defaults to as-needed).
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-edx",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "ESLint config for edX JavaScript code.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Thanks in advance for a thumb from anybody who thumbsed the PR that preceded this release: @andy-armstrong, @dsjen, @AlasdairSwan or @alisan617.

(Why 1.2.1 rather than 1.3.0? The change in #17 shouldn't make any existing code start failing - the new `strict` option defaults to the old one unless you explicitly opt-in to `"env": "node"`.)