### PR TITLE
Change sourceType settings so that CommonJS and ES2015 modules both work

### DIFF
--- a/packages/eslint-config-edx/.eslintrc.json
+++ b/packages/eslint-config-edx/.eslintrc.json
@@ -8,11 +8,7 @@
     },
     "extends": "airbnb-base",
     "parserOptions": {
-        "ecmaVersion": 8,
-        "ecmaFeatures": {
-            "globalReturn": false
-        },
-        "sourceType": "script"
+        "ecmaVersion": 8
     },
     "plugins": [
         "dollar-sign"

--- a/packages/eslint-config-edx/test/amd-test.js
+++ b/packages/eslint-config-edx/test/amd-test.js
@@ -1,7 +1,0 @@
-((define) => {
-  'use strict';
-
-  define(['./test.js'], (test) => {
-    test();
-  });
-})();

--- a/packages/eslint-config-edx/test/browser/es2015-test.js
+++ b/packages/eslint-config-edx/test/browser/es2015-test.js
@@ -1,0 +1,3 @@
+import test from '../test';
+
+test();

--- a/packages/eslint-config-edx/test/node/.eslintrc.json
+++ b/packages/eslint-config-edx/test/node/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "parserOptions": {
+    "sourceType": "script"
+  }
+}

--- a/packages/eslint-config-edx/test/node/commonjs-test.js
+++ b/packages/eslint-config-edx/test/node/commonjs-test.js
@@ -2,6 +2,6 @@
 
 'use strict';
 
-const test = require('./test.js');
+const test = require('../test.js');
 
 test();

--- a/packages/eslint-config-edx/test/test.js
+++ b/packages/eslint-config-edx/test/test.js
@@ -1,31 +1,17 @@
-((root, factory) => {
-  'use strict';
-
-  if (typeof define === 'function' && define.amd) {
-    // Export as AMD, for RequireJS
-    define([], factory);
-  } else if (typeof module === 'object' && module.exports) {
-    // Export as CommonJS, for Node
-    module.exports = factory();
-  }
-})(this, () => {
-  'use strict';
-
-  return () => {
-    const propertyQuote = {
-      bar: 'buzz',
-      'mixed-quote-prop': 'mixed quotes are ok!',
-    };
-    const simpleESLintTest = 'This file should have no errors';
-
-    if (propertyQuote.bar === 'X') {
-      return false;
-    }
-
-    if (simpleESLintTest.charAt(0) === 'X') {
-      return false;
-    }
-
-    return true;
+export default () => {
+  const propertyQuote = {
+    bar: 'buzz',
+    'mixed-quote-prop': 'mixed quotes are ok!',
   };
-});
+  const simpleESLintTest = 'This file should have no errors';
+
+  if (propertyQuote.bar === 'X') {
+    return false;
+  }
+
+  if (simpleESLintTest.charAt(0) === 'X') {
+    return false;
+  }
+
+  return true;
+};


### PR DESCRIPTION
While trying to implement it in edx-platform, I discovered that `eslint-config-edx@2.0.0` couldn't lint ES2015 modules, which is kind of the whole point. This was due to me leaving `sourceType: 'script'` set in the ES2015 config, where it should have been `sourceType: 'module'` (the default) to properly lint ES2015 modules.

I also deleted the AMD test from the ES2015 package, because we won't be supporting writing ES2015 AMD modules.

The test folder now properly demonstrates how to write ES2015 modules that are destined for Babel/Webpack alongside Node scripts that will run in Node 6 and get both passing the linter.