### PR TITLE
v3.0.0 (breaking): dependency upgrades

### DIFF
--- a/packages/eslint-config-edx-es5/CHANGELOG.md
+++ b/packages/eslint-config-edx-es5/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.0 (04-20-2017)
+* (BREAKING) Upgrade eslint-config-airbnb-base from ^3.0.1 to ^11.1.0
+* Upgrade eslint-plugin-import from ^1.7.0 to ^2.2.0
+
 ## 2.0.0 (02-24-2017)
 * Upgrade ESLint from v2 to v3, for compatibility with eslint-config-edx
 

--- a/packages/eslint-config-edx-es5/package.json
+++ b/packages/eslint-config-edx-es5/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-edx-es5",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "ESLint config for edX JavaScript ES5 code.",
   "main": "index.js",
   "repository": {
@@ -20,8 +20,8 @@
   "homepage": "https://github.com/edx/eslint-config-edx/blob/master/packages/eslint-config-edx-es5/README.md",
   "dependencies": {
     "eslint": "^3.16.0",
-    "eslint-config-airbnb-base": "^3.0.1",
+    "eslint-config-airbnb-base": "^11.1.0",
     "eslint-plugin-dollar-sign": "1.0.0",
-    "eslint-plugin-import": "^1.7.0"
+    "eslint-plugin-import": "^2.2.0"
   }
 }


### PR DESCRIPTION
A couple dependency upgrades to sync with `eslint-config-edx`:

* (BREAKING) Upgrade `eslint-config-airbnb-base` from ^3.0.1 to ^11.1.0
* Upgrade `eslint-plugin-import` from ^1.7.0 to ^2.2.0