### PR TITLE
jsx support

### DIFF
--- a/packages/eslint-config-edx/.eslintrc.json
+++ b/packages/eslint-config-edx/.eslintrc.json
@@ -18,6 +18,7 @@
     ],
     "rules": {
         "dollar-sign/dollar-sign": ["error", "ignoreProperties"],
-        "react/no-array-index-key": "off"
+        "react/no-array-index-key": "off",
+        "strict": "off"
     }
 }

--- a/packages/eslint-config-edx/.eslintrc.json
+++ b/packages/eslint-config-edx/.eslintrc.json
@@ -18,7 +18,6 @@
     ],
     "rules": {
         "dollar-sign/dollar-sign": ["error", "ignoreProperties"],
-        "react/no-array-index-key": "off",
         "strict": "off"
     }
 }

--- a/packages/eslint-config-edx/.eslintrc.json
+++ b/packages/eslint-config-edx/.eslintrc.json
@@ -6,14 +6,18 @@
         "jasmine": true,
         "jquery": true
     },
-    "extends": "airbnb-base",
+    "extends": "airbnb",
     "parserOptions": {
-        "ecmaVersion": 8
+        "ecmaVersion": 8,
+        "ecmaFeatures": {
+          "jsx": true
+        }
     },
     "plugins": [
         "dollar-sign"
     ],
     "rules": {
-        "dollar-sign/dollar-sign": ["error", "ignoreProperties"]
+        "dollar-sign/dollar-sign": ["error", "ignoreProperties"],
+        "react/no-array-index-key": "off"
     }
 }

--- a/packages/eslint-config-edx/package.json
+++ b/packages/eslint-config-edx/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/edx/eslint-config-edx/blob/master/packages/eslint-config-edx/README.md",
   "dependencies": {
     "eslint": "^3.16.0",
-    "eslint-config-airbnb-base": "^11.1.0",
+    "eslint-config-airbnb": "^15.0.1",
     "eslint-plugin-dollar-sign": "1.0.0",
     "eslint-plugin-import": "^2.2.0"
   }

--- a/packages/eslint-config-edx/package.json
+++ b/packages/eslint-config-edx/package.json
@@ -22,6 +22,8 @@
     "eslint": "^3.16.0",
     "eslint-config-airbnb": "^15.0.1",
     "eslint-plugin-dollar-sign": "1.0.0",
-    "eslint-plugin-import": "^2.2.0"
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^5.0.3",
+    "eslint-plugin-react": "^7.1.0"
   }
 }


### PR DESCRIPTION
Updates eslint-config-edx (the es2015 one) to include support for jsx syntax linting via eslint-config-airbnb. Also adds a couple of ignore rules.

cc @edx/fedx-team