### PR TITLE
Use indent=4 in es2015

### DIFF
--- a/packages/eslint-config-edx/.eslintrc.json
+++ b/packages/eslint-config-edx/.eslintrc.json
@@ -18,6 +18,7 @@
     ],
     "rules": {
         "dollar-sign/dollar-sign": ["error", "ignoreProperties"],
+        "indent": ["error", 4],
         "strict": "off",
         "class-methods-use-this": "off"
     }

--- a/packages/eslint-config-edx/README.md
+++ b/packages/eslint-config-edx/README.md
@@ -24,3 +24,17 @@ For the most part, edX follows the thoroughly documented [Airbnb JavaScript Styl
     // Linter error
     const fooSpan = $('span#foo');
     ```
+
+####[`indent`](http://eslint.org/docs/rules/indent)
+- **Setting**: `["error", 4]`
+- **Explanation**: edX is standardized on indenting all code with four spaces. The JavaScript community generally prefers two spaces; edX uses four because of our use of Python (see [PEP8](https://www.python.org/dev/peps/pep-0008/)) and the desire to have consistency in our codebases.
+- **Example**:
+
+	```javascript
+	// Correct pattern
+	var example = function() {
+	    if (numberOfSpaces !== 4) {
+	        throw new Error('Use four spaces for indentation.');
+	    }
+	};
+	```

--- a/packages/eslint-config-edx/test/test.js
+++ b/packages/eslint-config-edx/test/test.js
@@ -1,17 +1,17 @@
 export default () => {
-  const propertyQuote = {
-    bar: 'buzz',
-    'mixed-quote-prop': 'mixed quotes are ok!',
-  };
-  const simpleESLintTest = 'This file should have no errors';
+    const propertyQuote = {
+        bar: 'buzz',
+        'mixed-quote-prop': 'mixed quotes are ok!',
+    };
+    const simpleESLintTest = 'This file should have no errors';
 
-  if (propertyQuote.bar === 'X') {
-    return false;
-  }
+    if (propertyQuote.bar === 'X') {
+        return false;
+    }
 
-  if (simpleESLintTest.charAt(0) === 'X') {
-    return false;
-  }
+    if (simpleESLintTest.charAt(0) === 'X') {
+        return false;
+    }
 
-  return true;
+    return true;
 };


### PR DESCRIPTION
Our es5 rules use indent=4, and the rationale still holds for es2015.

Plus, this way converting to es2015 won't have us changing every single line in our code.