### PR TITLE
Pin eslint-plugin-jsx-a11y to 6.0.3.

### DIFF
--- a/packages/eslint-config-edx/CHANGELOG.md
+++ b/packages/eslint-config-edx/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.0.4 (2018-07-05)
+* Pin eslint-plugin-jsx-a11y to 6.0.3
+
 ## 2.0.1 (03-31-2017)
 * Fix linting of ES2015 modules
 

--- a/packages/eslint-config-edx/package-lock.json
+++ b/packages/eslint-config-edx/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-edx",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/eslint-config-edx/package.json
+++ b/packages/eslint-config-edx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-edx",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "description": "ESLint config for edX JavaScript ES2015+ code.",
   "main": "index.js",
   "repository": {
@@ -23,7 +23,7 @@
     "eslint-config-airbnb": "^16.1.0",
     "eslint-plugin-dollar-sign": "^1.0.1",
     "eslint-plugin-import": "^2.8.0",
-    "eslint-plugin-jsx-a11y": "^6.0.2",
+    "eslint-plugin-jsx-a11y": "6.0.3",
     "eslint-plugin-react": "^7.5.1"
   }
 }


### PR DESCRIPTION
There's a bug in eslint-plugin-jsx-a11y@6.1.0 - https://github.com/evcohen/eslint-plugin-jsx-a11y/issues/454 - that's causing eslint to spit out a bunch of unintended errors.  This PR pins eslint-plugin-jsx-a11y to 6.0.3 (minor bump from 6.0.2).  Previously, the "^6.0.2" dependency string made it so that the latest package with the same major version was installed, i.e. 6.1.0, which we don't want.